### PR TITLE
Set xhr.withCredentials = true in loadFeaturesXhr()

### DIFF
--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -62,6 +62,7 @@ export function loadFeaturesXhr(url, format, success, failure) {
       if (format.getType() == FormatType.ARRAY_BUFFER) {
         xhr.responseType = 'arraybuffer';
       }
+      xhr.withCredentials = true;
       /**
        * @param {Event} event Event.
        * @private


### PR DESCRIPTION
This pull request is related to https://github.com/openlayers/openlayers/issues/5244.

It adds `xhr.withCredentials = true;` to `loadFeaturesXhr()` so that cookies are sent when pulling GeoJSON from a cross-origin domain.

Currently, adding a GeoJSON source from another domain that is authenticated via a session cookie returns a 403 response, while opening the same URL in another tab returns a 200.